### PR TITLE
Ignore GHSA-f8q6-p94x-37v3 advisory

### DIFF
--- a/config.json
+++ b/config.json
@@ -44,6 +44,9 @@
       },
       {
         "advisory": "https://github.com/advisories/GHSA-36jr-mh4h-2g58"
+      },
+      {
+        "advisory": "https://github.com/advisories/GHSA-f8q6-p94x-37v3"
       }
     ],
     "comments": [


### PR DESCRIPTION
This advisory is for a ReDoS attack which we've considered out of scope normally, so we don't want our bots to alert on this issue.