### PR TITLE
Ignore GHSA-9vvw-cc9w-f27h during auditing

### DIFF
--- a/config.json
+++ b/config.json
@@ -56,6 +56,9 @@
       },
       {
         "advisory": "https://github.com/advisories/GHSA-w573-4hg7-7wgq"
+      },
+      {
+        "advisory": "https://github.com/advisories/GHSA-9vvw-cc9w-f27h"
       }
     ],
     "comments": [


### PR DESCRIPTION
This is a low concern as a ReDoS attack, so just going to ignore it.