### PR TITLE
Ignore unmaintained warning for twoway

### DIFF
--- a/config.json
+++ b/config.json
@@ -11,6 +11,10 @@
       {
         "advisory": "RUSTSEC-2021-0139",
         "issue": "https://github.com/brave/brave-browser/issues/25711"
+      },
+      {
+        "advisory": "RUSTSEC-2021-0146",
+        "issue": "https://github.com/brave/brave-browser/issues/28228"
       }
     ],
     "npm": [


### PR DESCRIPTION
This isn't release-blocking; there are no known issues, we just can't expect upstream response if one is reported. So ignore for now to reduce lint noise.

This should be removed when we're no longer shipping builds using the dependency, probably via https://github.com/brave/brave-core/pull/17037