### PR TITLE
Added RUSTSEC-2023-0019

### DIFF
--- a/config.json
+++ b/config.json
@@ -15,6 +15,10 @@
       {
         "advisory": "RUSTSEC-2021-0146",
         "issue": "https://github.com/brave/brave-browser/issues/28228"
+      },
+      {
+        "advisory": "RUSTSEC-2023-0019",
+        "issue": "https://github.com/brave/brave-browser/issues/29079"
       }
     ],
     "npm": [


### PR DESCRIPTION
This advisory is about a package no longer being maintained. Not urgent, should not block automated public releases.