### PR TITLE
Ignore atty RUSTSEC-2021-0145

### DIFF
--- a/config.json
+++ b/config.json
@@ -13,6 +13,10 @@
         "issue": "https://github.com/brave/brave-browser/issues/25711"
       },
       {
+        "advisory": "RUSTSEC-2021-0145",
+        "issue": "https://github.com/brave/brave-browser/issues/32142"
+      },
+      {
         "advisory": "RUSTSEC-2021-0146",
         "issue": "https://github.com/brave/brave-browser/issues/28228"
       },


### PR DESCRIPTION
We're using this (a) in cxxbridge-cmd where we use the native allocator and the unaligned read isn't exploitable, and (b) as a transitive dev-dependency through older versions of the criterion benchmark framework. In neither case do we use the code in question in brave-core. However, we should be alert to new uses until we can update dependencies and clear this exception.

Resolves https://github.com/brave/brave-browser/issues/32142