### PR TITLE
Ignore npm ip package vulnerability

### DIFF
--- a/config.json
+++ b/config.json
@@ -116,11 +116,15 @@
       {
         "advisory": "https://github.com/advisories/GHSA-7fh5-64p2-3v2j",
         "issue": "https://github.com/brave/brave-browser/issues/33384"
-      }
+      },
+      {
+        "advisory": "https://github.com/advisories/GHSA-78xj-cgh5-2h22",
+        "issue": "https://github.com/brave/brave-browser/issues/35926"
     ],
     "comments": [
       "GHSA-mhxj-85r3-2x55 is DoS detecting file type of a malformed MKV file"
     , "GHSA-7fh5-64p2-3v2j is a defect of npm module 'postcss' depended on by storybook which I stuggle to believe could ever have any security implications"
+    , "GHSA-78xj-cgh5-2h22 is failing to distinguish public/private ip addresses; we believe our use is not vulnerable"
     , "All other npm advisories are for regular expression denial of service vulnerabilities"
     ]
   }

--- a/config.json
+++ b/config.json
@@ -120,6 +120,7 @@
       {
         "advisory": "https://github.com/advisories/GHSA-78xj-cgh5-2h22",
         "issue": "https://github.com/brave/brave-browser/issues/35926"
+      }
     ],
     "comments": [
       "GHSA-mhxj-85r3-2x55 is DoS detecting file type of a malformed MKV file"


### PR DESCRIPTION
Allow https://github.com/advisories/GHSA-78xj-cgh5-2h22

There's no fix outside transitive dependencies migrating to a maintanted package and we don't believe our use is vulnerable.