### PR TITLE
Ignore RUSTSEC-2023-0081 unmaintained safemem

### DIFF
--- a/config.json
+++ b/config.json
@@ -35,6 +35,10 @@
       {
         "advisory": "RUSTSEC-2022-0093",
         "issue": "https://github.com/brave/brave-browser/issues/32236"
+      },
+      {
+        "advisory": "RUSTSEC-2023-0081",
+        "issue": "https://github.com/brave/brave-browser/issues/36616"
       }
     ],
     "npm": [


### PR DESCRIPTION
This crate is unmaintained. Ignore the warning until lol_html (our only path to the dependency) publishes an update removing it.

Resolves https://github.com/brave/brave-browser/issues/36616