### PR TITLE
Revert "config.json: ignore elliptic findings (#51)"

### DIFF
--- a/config.json
+++ b/config.json
@@ -144,22 +144,6 @@
       {
         "advisory": "https://github.com/advisories/GHSA-3h5v-q93c-6h6q",
         "issue": "https://github.com/brave/brave-browser/issues/39118"
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-49q7-c7j4-3p7m",
-        "issue": "https://github.com/brave/brave-browser/issues/40276"
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-977x-g7h5-7qgw",
-        "issue": "https://github.com/brave/brave-browser/issues/40277"
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-f7q4-pwc6-w24p",
-        "issue": "https://github.com/brave/brave-browser/issues/40278"
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-952p-6rrq-rcjv",
-        "issue": "https://github.com/brave/brave-browser/issues/40591"
       }
     ],
     "comments": [


### PR DESCRIPTION
This reverts commit 03492c65c408315c7407db82c24353fbaa3f5568.