### PR TITLE
Remove GHSA-fc9h-whq2-v747 now that a fix is available

### DIFF
--- a/config.json
+++ b/config.json
@@ -152,10 +152,6 @@
       {
         "advisory": "https://github.com/advisories/GHSA-9wv6-86v2-598j",
         "issue": "https://github.com/brave/brave-browser/issues/40946"
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-fc9h-whq2-v747",
-        "issue": "https://github.com/brave/brave-browser/issues/41714"
       }
     ],
     "comments": [


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/41714

Originally, this was added because a fix wasn't yet available and we reviewed the issue and didn't believe it would present issues. The code paths that rely on this transitive dependency are almost always dead code paths for us. In the cases where it wouldn't have been it would have produced false negative verifications. While this would have been annoying to encounter it would still fail safely. Now that a fix is available, we can bump it to fix it properly.