### PR TITLE
Improved create_pull_request.yml

### DIFF
--- a/.github/workflows/create_pull_request.yml
+++ b/.github/workflows/create_pull_request.yml
@@ -70,8 +70,8 @@ jobs:
               ,) echo "ERROR: either the advisory, or the issue must be specified" >&2; exit 2;;
               ,*) issue_title="Audit finding: $advisory_url"
                   issue_repo="$(cut -d/ -f4-5 <<<"$issues_url")"
-                  issue_url="$(gh -R "${issue_repo:?}" issue list -l bot/type/audit -S "${issue_title:?}" \
-                      --json title,url -q '.[]|select(.title=="'"$issue_title"'").url')";;
+                  issue_url="$(gh -R "${issue_repo:?}" issue list -A brave-builds -l bot/type/audit \
+                      -S "${issue_title:?}" --json title,url -q '.[]|select(.title=="'"$issue_title"'").url')";;
               *,) issue_title="$(gh issue view "$issue_url" --json title -q .title)"
                   advisory_id="${issue_title##*/}"
                   advisory_url="${issue_title#Audit finding: }";;


### PR DESCRIPTION
The workflow to create a PR to ignore a finding currently requires both an issue URL and an advisory ID/URL.

After this is merged it will require either the issue ID/URL, or the advisory ID/URL. Both can be provided, but if one is missing, the value will be calculated.