### PR TITLE
Fixed RUSTSEC-2025-0021 suppression

### DIFF
--- a/config.json
+++ b/config.json
@@ -38,7 +38,7 @@
         "issue": "https://github.com/brave/brave-core/security/dependabot/156"
       },
       {
-        "advisory": "https://rustsec.org/advisories/RUSTSEC-2025-0021",
+        "advisory": "RUSTSEC-2025-0021",
         "issue": "https://github.com/brave/brave-browser/issues/45207",
         "comment": "see https://bravesoftware.slack.com/archives/C7VLGSR55/p1744056912816059?thread_ts=1743770397.337459&cid=C7VLGSR55"
       }


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/45273

The workflow to add suppressions has a bug - it uses the full url for cargo (https://rustsec.org/advisories/RUSTSEC-2025-0021), when it should only use the id (RUSTSEC-2025-0021). I'll open a PR for the workflow, but for now, let's just fix the suppression.