### PR TITLE
Remove 39 stale npm ignore entries

### DIFF
--- a/config.json
+++ b/config.json
@@ -136,45 +136,12 @@
     ],
     "npm": [
       {
-        "advisory": "https://github.com/advisories/GHSA-p8p7-x288-28g6",
-        "issue": "https://github.com/brave/brave-browser/issues/29120"
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-hhhv-q57g-882q",
-        "issue": "https://github.com/brave/brave-browser/issues/36615"
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-2p57-rm9w-gvfp",
-        "issue": "https://github.com/brave/brave-browser/issues/38762"
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-grv7-fg5c-xmjg",
-        "issue": "https://github.com/brave/brave-browser/issues/38940"
-      },
-      {
         "advisory": "https://github.com/advisories/GHSA-3h5v-q93c-6h6q",
         "issue": "https://github.com/brave/brave-browser/issues/39118"
       },
       {
-        "advisory": "https://github.com/advisories/GHSA-952p-6rrq-rcjv",
-        "issue": "https://github.com/brave/brave-browser/issues/40668"
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-3xgq-45jj-v275",
-        "issue": "https://github.com/brave/brave-browser/issues/42340"
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-rhx6-c78j-4q9w",
-        "issue": "https://github.com/brave/brave-browser/issues/42721"
-      },
-      {
         "advisory": "https://github.com/advisories/GHSA-mwcw-c2x4-8c55",
         "issue": "https://github.com/brave/brave-browser/issues/42784"
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-968p-4wvh-cqc8",
-        "issue": "https://github.com/brave/brave-browser/issues/44619",
-        "comment": "ReDoS"
       },
       {
         "advisory": "https://github.com/advisories/GHSA-m5qc-5hw7-8vg7",
@@ -185,46 +152,8 @@
         "issue": ""
       },
       {
-        "advisory": "https://github.com/advisories/GHSA-3gc7-fjrx-p6mg",
-        "issue": "https://github.com/brave/brave-browser/issues/45258",
-        "comment": "no fix available yet"
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-cxrh-j4jr-qwg3",
-        "issue": "https://github.com/brave/brave-browser/issues/46108"
-      },
-      {
         "advisory": "https://github.com/advisories/GHSA-v6h2-p8h4-qcjw",
         "issue": "https://github.com/brave/brave-browser/issues/46722"
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-xffm-g5w8-qvg7",
-        "issue": "https://github.com/brave/brave-browser/issues/47767"
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-fjxv-7rqg-78g4",
-        "issue": "https://github.com/brave/brave-browser/issues/47800"
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-cpq7-6gpm-g9rc",
-        "issue": "https://github.com/brave/brave-browser/issues/48640"
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-4hjh-wcwx-xvwj",
-        "issue": "https://github.com/brave/brave-browser/issues/49203"
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-qjqf-7j6f-82c4",
-        "issue": "https://github.com/brave/brave-browser/issues/49295",
-        "comment": "See https://bravesoftware.slack.com/archives/C7VLGSR55/p1757986985411379?thread_ts=1757982273.569489&cid=C7VLGSR55 for triage and analysis"
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-rx8g-88g5-qh64",
-        "issue": "https://github.com/brave/brave-browser/issues/49868"
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-ffrw-9mx8-89p8",
-        "issue": "https://github.com/brave/brave-browser/issues/49869"
       },
       {
         "advisory": "https://github.com/advisories/GHSA-5j98-mcp5-4vw2",
@@ -236,10 +165,6 @@
         "issue": "https://github.com/brave/brave-browser/issues/51071"
       },
       {
-        "advisory": "https://github.com/advisories/GHSA-6rw7-vpxm-498p",
-        "issue": "https://github.com/brave/brave-browser/issues/51715"
-      },
-      {
         "advisory": "https://github.com/advisories/GHSA-848j-6mx2-7j84",
         "issue": "https://github.com/brave/brave-browser/issues/51895",
         "comment": "We do not perform signing with this library, so should not block builds. It should be bumped still, but to keep trains moving we can ignore for now."
@@ -249,36 +174,12 @@
         "issue": "https://github.com/brave/brave-browser/issues/52000"
       },
       {
-        "advisory": "https://github.com/advisories/GHSA-p5wg-g6qr-c7cg",
-        "issue": "https://github.com/brave/brave-browser/issues/52398",
-        "comment": "temporary per https://bravesoftware.slack.com/archives/C7VLGSR55/p1769785994683619?thread_ts=1769707476.680959&cid=C7VLGSR55; also maybe not exploitable?"
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-w7fw-mjwx-w883",
-        "issue": "https://github.com/brave/brave-browser/issues/52820"
-      },
-      {
         "advisory": "https://github.com/advisories/GHSA-2g4f-4pwh-qvx6",
         "issue": "https://github.com/brave/brave-browser/issues/52943"
       },
       {
         "advisory": "https://github.com/advisories/GHSA-3ppc-4f35-3m26",
         "issue": "https://github.com/brave/brave-browser/issues/52970"
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-f7gr-6p89-r883",
-        "issue": "https://github.com/brave/brave-browser/issues/52994",
-        "comment": "brave-core does not use server-side rendering"
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-m56q-vw4c-c2cp",
-        "issue": "https://github.com/brave/brave-browser/issues/52993",
-        "comment": "brave-core does not use server-side rendering"
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-crpf-4hrx-3jrp",
-        "issue": "https://github.com/brave/brave-browser/issues/53013",
-        "comment": "brave-core does not use server-side rendering"
       },
       {
         "advisory": "https://github.com/advisories/GHSA-378v-28hj-76wf",
@@ -293,67 +194,8 @@
         "issue": "https://github.com/brave/brave-browser/issues/53182"
       },
       {
-        "advisory": "https://github.com/advisories/GHSA-phwv-c562-gvmh",
-        "issue": "https://github.com/brave/brave-browser/issues/53184",
-        "comment": "SSR not used"
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-qpx9-hpmf-5gmw",
-        "issue": ""
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-vpq2-c234-7xj6",
-        "issue": "https://github.com/brave/brave-browser/issues/53375"
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-25h7-pfq9-p65f",
-        "issue": "https://github.com/brave/brave-browser/issues/53608"
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-gmq8-994r-jv83",
-        "issue": "https://github.com/brave/brave-browser/issues/53653"
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-677m-j7p3-52f9",
-        "issue": "https://github.com/brave/brave-browser/issues/53777"
-      },
-      {
         "advisory": "https://github.com/advisories/GHSA-c2c7-rcm5-vvqj",
         "issue": "https://github.com/brave/brave-browser/issues/53966"
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-37ch-88jc-xwx2",
-        "issue": "https://github.com/brave/brave-browser/issues/54051"
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-3p68-rc4w-qgx5",
-        "issue": "https://github.com/brave/brave-browser/issues/54376"
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-2v35-w6hq-6mfw",
-        "issue": "https://github.com/brave/brave-browser/issues/54872"
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-v39h-62p7-jpjc",
-        "issue": "https://github.com/brave/brave-browser/issues/55388"
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-v39h-62p7-jpjc",
-        "issue": "https://github.com/brave/brave-browser/issues/55388"
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-fv7c-fp4j-7gwp",
-        "issue": "https://github.com/brave/brave-browser/issues/55389"
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-pr6f-5x2q-rwfp",
-        "issue": "https://github.com/brave/brave-browser/issues/55538",
-        "comment": "SSR not used"
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-rcqx-6q8c-2c42",
-        "issue": "https://github.com/brave/brave-browser/issues/55539",
-        "comment": "https://bravesoftware.slack.com/archives/C7VLGSR55/p1778810466833949?thread_ts=1778804914.499019&cid=C7VLGSR55"
       },
       {
         "advisory": "https://github.com/advisories/GHSA-58qx-3vcg-4xpx",
@@ -364,24 +206,12 @@
         "issue": "https://github.com/brave/brave-browser/issues/55644"
       },
       {
-        "advisory": "https://github.com/advisories/GHSA-q8mj-m7cp-5q26",
-        "issue": "https://github.com/brave/brave-browser/issues/55767"
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-ph9p-34f9-6g65",
-        "issue": "https://github.com/brave/brave-browser/issues/55852"
-      },
-      {
         "advisory": "https://github.com/advisories/GHSA-h67p-54hq-rp68",
         "issue": "https://github.com/brave/brave-browser/issues/56409"
       },
       {
         "advisory": "https://github.com/advisories/GHSA-96hv-2xvq-fx4p",
         "issue": "https://github.com/brave/brave-browser/issues/56413"
-      },
-      {
-        "advisory": "https://github.com/advisories/GHSA-xcpc-8h2w-3j85",
-        "issue": "https://github.com/brave/brave-browser/issues/57307"
       },
       {
         "advisory": "https://github.com/advisories/GHSA-395f-4hp3-45gv",
@@ -434,6 +264,10 @@
       {
         "advisory": "https://github.com/advisories/GHSA-2v37-7h3g-55p8",
         "issue": "https://github.com/brave/brave-browser/issues/57977"
+      },
+      {
+        "advisory": "https://github.com/advisories/GHSA-xcpc-8h2w-3j85",
+        "issue": "https://github.com/brave/brave-browser/issues/57307"
       }
     ],
     "comments": []


### PR DESCRIPTION
Removes entries where packages are no longer in brave-core's lockfile or are at/above the patched version. Kept GHSA-xcpc-8h2w-3j85 (adm-zip) — still affects vendor/web-discovery-project. Verified locally with `audit_deps.py`.